### PR TITLE
移除冗余事件并支持LLM环境变量

### DIFF
--- a/git_workspace_agent/frontend/index.html
+++ b/git_workspace_agent/frontend/index.html
@@ -379,12 +379,8 @@
 
         if (eventType === "conversation-ready") {
           updateSummary({ status: "就绪" });
-        } else if (eventType === "message-queued") {
-          updateSummary({ status: "排队中" });
         } else if (eventType === "conversation-finished") {
           updateSummary({ status: payload?.agent_status ?? "已完成" });
-        } else if (eventType === "cleanup-complete") {
-          updateSummary({ status: "清理完成" });
         } else if (eventType === "error") {
           updateSummary({ status: "错误" });
         } else if (eventType === "agent-event" && payload?.event_type) {

--- a/git_workspace_agent/server.py
+++ b/git_workspace_agent/server.py
@@ -279,10 +279,13 @@ async def handle_conversation(request: ConversationRequest) -> StreamingResponse
     api_key = os.getenv("LITELLM_API_KEY")
     assert api_key is not None, "未设置 LITELLM_API_KEY 环境变量。"
 
+    model = os.getenv("LLM_MODEL") or "openai/qwen3-next-80b-a3b-instruct"
+    base_url = os.getenv("LLM_BASE_URL") or "https://dashscope.aliyuncs.com/compatible-mode/v1"
+
     llm = LLM(
         service_id="main-llm",
-        model="openai/qwen3-next-80b-a3b-instruct",
-        base_url="https://dashscope.aliyuncs.com/compatible-mode/v1",
+        model=model,
+        base_url=base_url,
         api_key=SecretStr(api_key),
     )
 
@@ -408,14 +411,6 @@ async def handle_conversation(request: ConversationRequest) -> StreamingResponse
                     logger.info("\n📋 对话 ID：%s", conversation.state.id)
                     logger.info("📝 正在发送消息…")
                     conversation.send_message(request.message)
-                    push_event(
-                        "message-queued",
-                        {
-                            "conversation_id": conversation_id_str,
-                            "workspace_id": workspace_id,
-                            "message": request.message,
-                        },
-                    )
 
                     logger.info("🚀 正在运行对话…")
                     conversation.run()
@@ -455,13 +450,6 @@ async def handle_conversation(request: ConversationRequest) -> StreamingResponse
                         conversation.close()
                     except Exception:  # noqa: BLE001
                         logger.exception("关闭会话失败")
-                push_event(
-                    "cleanup-complete",
-                    {
-                        "conversation_id": conversation_id_holder["id"],
-                        "workspace_id": workspace_id,
-                    },
-                )
                 finish_stream()
 
         worker_task = asyncio.create_task(asyncio.to_thread(worker))


### PR DESCRIPTION
## Summary
- 移除 `message-queued` 与 `cleanup-complete` 事件推送及前端状态处理
- 支持通过 `LLM_MODEL` 与 `LLM_BASE_URL` 环境变量配置沙箱服务器所使用的 LLM

## Testing
- 未运行测试（变更范围较小）

------
https://chatgpt.com/codex/tasks/task_e_68ec8ca269d48321af5f50d9b92944d4